### PR TITLE
Bump version to 1.0.3 and backfill 1.0.x changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> **Note:** This repository is the `guideline-tech` fork of
+> [`queue-bus/sidekiq-bus`](https://github.com/queue-bus/sidekiq-bus). The `1.0.x`
+> series diverges from upstream to support scheduling the queue-bus heartbeat via
+> Sidekiq Enterprise periodic jobs (`config.periodic`) instead of taking a hard
+> runtime dependency on `sidekiq-scheduler`, which is the scheduler our apps use.
+
 ## [Unreleased]
+
+## [1.0.3]
+
+### Changed
+- Synced `SidekiqBus::VERSION` to the released tag; the constant had lagged at `1.0.1`.
+- Documented the fork's divergence from upstream `queue-bus/sidekiq-bus` (see note above).
+
+## [1.0.2] - 2025-05-22
+
+### Changed
+- Raised the upper bound on `sidekiq` to allow Sidekiq 7 (`>= 3.0.0, < 8.0`).
+- Bumped Ruby to 3.3.9.
+
+## [1.0.1] - 2023-12-12
+
+### Added
+- Sidekiq Enterprise support: when `Sidekiq::Enterprise` is defined, the queue-bus
+  heartbeat is registered as a Sidekiq Enterprise periodic job rather than through
+  `sidekiq-scheduler`.
+
+## [1.0.0] - 2023-10-17
+
+### Changed
+- Expanded the `sidekiq` requirement to allow versions below 7.
+- Removed the hard `sidekiq-scheduler` runtime dependency; it is now required lazily
+  (and raises with a clear message if missing) only on the non-Enterprise heartbeat path.
 
 ## [0.9.0] - 2019-12-03
 

--- a/lib/sidekiq_bus/version.rb
+++ b/lib/sidekiq_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqBus
-  VERSION = '1.0.1'
+  VERSION = '1.0.3'
 end


### PR DESCRIPTION
## Summary

Bumps `SidekiqBus::VERSION` to `1.0.3` and backfills the changelog for the `1.0.x` line.

`version.rb` had lagged at `1.0.1` even though tags `1.0.0`–`1.0.2` were cut, so this resyncs the constant to a fresh `1.0.3`.

## Changes

- `version.rb`: `1.0.1` → `1.0.3`
- `CHANGELOG.md`: backfilled `1.0.0`, `1.0.1`, `1.0.2`, `1.0.3` entries (the log stopped at `0.9.0` in 2019) and added a note calling out that this repo is the `guideline-tech` fork of [`queue-bus/sidekiq-bus`](https://github.com/queue-bus/sidekiq-bus).

## Why the fork exists

The 1.0.x series diverges from upstream so the queue-bus heartbeat can be scheduled via Sidekiq Enterprise periodic jobs (`config.periodic`) instead of a hard runtime dependency on `sidekiq-scheduler` — the scheduler our apps deliberately avoid. Every public release of `sidekiq-bus` hard-depends on `sidekiq-scheduler`; this patch was never upstreamed.

No functional code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version constant only; no application or scheduling logic is modified.
> 
> **Overview**
> Aligns the gem release metadata with **1.0.3** and fills in release notes for the `1.0.x` line that were missing after the changelog stopped at `0.9.0`.
> 
> `SidekiqBus::VERSION` moves from `1.0.1` to **`1.0.3`** so the constant matches the tagged release (it had fallen behind `1.0.0`–`1.0.2`). **`CHANGELOG.md`** adds a fork note for `guideline-tech` vs upstream `queue-bus/sidekiq-bus` and documents **`1.0.0`–`1.0.3`** (Enterprise periodic heartbeat, relaxed `sidekiq-scheduler` dependency, Sidekiq 7 / Ruby bumps, and this version sync). **No runtime or library behavior changes** in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf536bc5d3291b1bd849bb66daba415a2650ff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->